### PR TITLE
Fix for OUJS

### DIFF
--- a/Pururin+.user.js
+++ b/Pururin+.user.js
@@ -2,6 +2,7 @@
 // @name         Pururin+ 
 // @version      1.00
 // @description  ;_;
+// @license      GPL-3.0
 // @author       ZerataX
 // @include      *.pururin.com/* 
 // @include      http://pururin.com/*


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify all of your affected scripts.

Until this change is made you will be unable to update those affected scripts.

Thanks,
OUJS Staff